### PR TITLE
Fix CSS closing brace typo

### DIFF
--- a/css/estilo.css
+++ b/css/estilo.css
@@ -1,7 +1,6 @@
 *{
     font-family: Cambria, Cochin, Georgia, Times, 'Times New Roman', serif;
 }
-}
 .width--height{
     height: 100px;
     }


### PR DESCRIPTION
## Summary
- remove an extra closing brace at the top of `estilo.css`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68475aa0a8ac832fbb55109b5548edea